### PR TITLE
Massaging linter with non_upper_case_globals.

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -17,6 +17,7 @@ use system::syscall::sys_chdir;
 
 use io::{Error, Result, Read, Write};
 
+#[allow(non_upper_case_globals)]
 static mut _args: *mut Vec<&'static str> = 0 as *mut Vec<&'static str>;
 
 /// An iterator over the arguments of a process, yielding a `String` value for each argument.

--- a/src/externs.rs
+++ b/src/externs.rs
@@ -1,5 +1,6 @@
 /// Errno
 #[no_mangle]
+#[allow(non_upper_case_globals)]
 pub static mut __errno: isize = 0;
 
 /// Memcpy


### PR DESCRIPTION
The latest version of Redox doesn't build with the latest Nightly due
to warnings-as-errors on non-uppercase globals.	   Fixing this by
allowing non-uppercase globals selectively when	   it's needed by
no_mangle.

See also rust-lang/rust issue 36258.